### PR TITLE
Improve the management of displaying the last read chapter, avoiding …

### DIFF
--- a/js/leerobras.js
+++ b/js/leerobras.js
@@ -29,11 +29,22 @@ document.addEventListener("DOMContentLoaded", function () {
         const discord = obra.querySelector("discord").textContent.trim();
         const aprobadaAutor = obra.querySelector("aprobadaAutor").textContent.trim();
 
-      //Ultimmo capitulo leido
-          const ultimaObra = localStorage.getItem("ultimaObra");
-          const ultimoCapitulo = localStorage.getItem("ultimoCapitulo");
-        booklastread.innerHTML = `${ultimaObra}·${ultimoCapitulo}`;
-        
+        //Ultimmo capitulo leido
+        const ultimaObra = localStorage.getItem("ultimaObra");
+        const ultimoCapitulo = localStorage.getItem("ultimoCapitulo");
+        // Evitar mostrar "null·null" o valores vacíos si aún no hay progreso
+        if (booklastread) {
+          if (ultimaObra && ultimoCapitulo) {
+            booklastread.textContent = `${ultimaObra}·${ultimoCapitulo}`;
+            booklastread.classList.remove('hide-on-tablet');
+          } else {
+            // Limpia el contenido y opcionalmente oculta el contenedor
+            booklastread.textContent = '';
+            // Si prefieres ocultarlo por completo, descomenta la siguiente línea:
+            // booklastread.style.display = 'none';
+          }
+        }
+
         let OKAutor = '';
         if (aprobadaAutor === 'si') {
           OKAutor = `


### PR DESCRIPTION
Mejorar la gestión de la visualización del último capítulo leído, evitando mostrar valores nulos y ocultando el contenedor si no hay progreso.

Antes:
<img width="1855" height="159" alt="image" src="https://github.com/user-attachments/assets/48328a90-73fb-43da-8ff1-af04a21ac0bc" />

Después:
<img width="1839" height="154" alt="image" src="https://github.com/user-attachments/assets/97b157cf-e2a7-44ee-be69-e01024ed10fd" />
