### PR TITLE
Corrección de redirección en 404.html

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,15 +3,28 @@
 <html lang="es">
   <head>
     <meta charset="UTF-8" />
-    <title>Redirigiendo...</title>
+    <title>Página no encontrada</title>
     <script>
-      // Redirige a index.html con hash, que tu código ya sabe manejar
-      const ruta = location.pathname.replace(/^\/|\/$/g, ""); // Ej: "CDMNQTMHC"
-      console.log(location.replace(`index.html#${ruta}`));
-      //location.replace(`index.html#${ruta}`);
+      let segundos = 3; // tiempo de espera en segundos
+
+      function actualizarMensaje() {
+        const mensaje = document.getElementById("contador");
+        mensaje.textContent = segundos;
+        if (segundos === 0) {
+          location.replace("index.html");
+        }
+        segundos--;
+      }
+
+      // Inicia cuenta regresiva
+      window.onload = () => {
+        actualizarMensaje();
+        setInterval(actualizarMensaje, 1000);
+      };
     </script>
   </head>
   <body>
-    <p>Redirigiendo a la página principal...</p>
+    <p>Redirigiendo a la página principal en <span id="contador">3</span> segundos...</p>
+    <p><a href="index.html">Haz clic aquí si no eres redirigido automáticamente</a></p>
   </body>
 </html>

--- a/js/leerobras.js
+++ b/js/leerobras.js
@@ -29,11 +29,22 @@ document.addEventListener("DOMContentLoaded", function () {
         const discord = obra.querySelector("discord").textContent.trim();
         const aprobadaAutor = obra.querySelector("aprobadaAutor").textContent.trim();
 
-      //Ultimmo capitulo leido
-          const ultimaObra = localStorage.getItem("ultimaObra");
-          const ultimoCapitulo = localStorage.getItem("ultimoCapitulo");
-        booklastread.innerHTML = `${ultimaObra}·${ultimoCapitulo}`;
-        
+        //Ultimmo capitulo leido
+        const ultimaObra = localStorage.getItem("ultimaObra");
+        const ultimoCapitulo = localStorage.getItem("ultimoCapitulo");
+        // Evitar mostrar "null·null" o valores vacíos si aún no hay progreso
+        if (booklastread) {
+          if (ultimaObra && ultimoCapitulo) {
+            booklastread.textContent = `${ultimaObra}·${ultimoCapitulo}`;
+            booklastread.classList.remove('hide-on-tablet');
+          } else {
+            // Limpia el contenido y opcionalmente oculta el contenedor
+            booklastread.textContent = '';
+            // Si prefieres ocultarlo por completo, descomenta la siguiente línea:
+            // booklastread.style.display = 'none';
+          }
+        }
+
         let OKAutor = '';
         if (aprobadaAutor === 'si') {
           OKAutor = `


### PR DESCRIPTION
Antes se construía un hash a partir de la ruta solicitada (location.pathname) y se redirigía inmediatamente a index.html#<ruta>, lo que mostraba abruptamente una obra “no encontrada” si el hash no existía.
Ahora se muestra una cuenta regresiva de 3 segundos con mensaje y un enlace manual a la página principal, manteniendo la redirección funcional.