### PR TITLE
Soluciona el problema del modo oscuro en el lector de PDF

### DIFF
--- a/js/lectorpdfmod.js
+++ b/js/lectorpdfmod.js
@@ -178,18 +178,28 @@ function actualizarBotonesNav(idx, capitulos, clave) {
  */
 function configurarModoOscuro() {
   const toggleMode = document.getElementById("toggleMode");
-  toggleMode.onclick = () => {
-    body.classList.toggle("dark-mode");
-    body.classList.toggle("light-mode");
-    toggleMode.textContent = body.classList.contains("dark-mode") ? "☀️" : "🌙";
-    localStorage.setItem("modoNocturno", body.classList.contains("dark-mode") ? "true" : "false");
+  const canvas = document.getElementById("pdfCanvas");
+  
+  const aplicarModo = (esOscuro) => {
+    body.classList.toggle("dark-mode", esOscuro);
+    body.classList.toggle("light-mode", !esOscuro);
+    toggleMode.textContent = esOscuro ? "☀️" : "🌙";
+    localStorage.setItem("modoNocturno", esOscuro);
+
+    // Forzar la eliminación del filtro directamente en el estilo del elemento
+    if (canvas) {
+      canvas.style.filter = 'none';
+    }
   };
 
-  if (localStorage.getItem("modoNocturno") === "true") {
-    body.classList.add("dark-mode");
-    body.classList.remove("light-mode");
-    toggleMode.textContent = "☀️";
-  }
+  toggleMode.onclick = () => {
+    const esOscuro = !body.classList.contains("dark-mode");
+    aplicarModo(esOscuro);
+  };
+
+  // Aplicar al cargar la página
+  const modoGuardado = localStorage.getItem("modoNocturno") === "true";
+  aplicarModo(modoGuardado);
 }
 
 /**


### PR DESCRIPTION
# Corrección del modo oscuro en el lector de PDF

Se corrigió un error en el lector de PDF donde la activación del modo oscuro afectaba negativamente al contenido del documento, invirtiendo sus colores y dificultando la lectura.

## Problema
Al activar el modo oscuro, una regla de CSS aplicaba un filtro:

```css
filter: invert(1) hue-rotate(180deg)...
```

sobre el elemento `<canvas>` que renderiza el PDF. Esto provocaba que:

* Las imágenes y otros elementos con color se distorsionaran completamente.
* El problema persistía incluso después de eliminar la regla CSS(se restauro después de que no solucionara el problema).

## Solución Implementada

Se realizaron los siguientes cambios para resolver el problema de manera definitiva:

* **JavaScript (lectorpdfmod.js)**:
  Se modificó la función `configurarModoOscuro` para que, al cambiar de modo, se establezca explícitamente:

  ```js
  canvas.style.filter = 'none';
  ```

  Este estilo en línea tiene mayor prioridad y anula cualquier regla CSS que pueda estar almacenada en la caché del navegador.

## Cómo verificar

1. Navega a la página de un capitulo.
2. Activa y desactiva el modo oscuro varias veces.

**Resultado esperado:**
El fondo de la página y la interfaz del lector cambian de color, pero el contenido del PDF (imágenes) permanece con sus colores originales e inalterados.

Imágenes de referencia:

Antes:
<img width="1864" height="925" alt="image" src="https://github.com/user-attachments/assets/af4ecde9-1f06-4452-977e-5018fcdeaa8b" />

Después:
<img width="1865" height="926" alt="image" src="https://github.com/user-attachments/assets/065c577a-ff99-4177-81a4-d60d00eb0a6f" />
